### PR TITLE
Add metadata convenience methods.  Fix stacktrace rendering.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'signing'
 
 group = 'com.hyp3r'
 archivesBaseName = 'kinesis-logback-appender'
-version = '0.0.3'
+version = '0.0.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/hyp3r/services/kinesis/logback/ext/KinesisLogger.java
+++ b/src/main/java/com/hyp3r/services/kinesis/logback/ext/KinesisLogger.java
@@ -6,6 +6,12 @@ import org.slf4j.Logger;
 import org.slf4j.MDC;
 import org.slf4j.ext.LoggerWrapper;
 
+import java.io.Closeable;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 
 public class KinesisLogger extends LoggerWrapper implements Logger {
@@ -21,10 +27,10 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
         kDebug(eventType, null, fmt, args);
     }
 
-    public void kDebug(String eventType, Map<String, String> mdc, String fmt, Object... args) {
+    public void kDebug(String eventType, Map<String, Object> mdc, String fmt, Object... args) {
         kDebug(eventType, null, mdc, fmt, args);
     }
-    public void kDebug(String eventType, String context, Map<String, String> mdc, String fmt, Object... args) {
+    public void kDebug(String eventType, String context, Map<String, Object> mdc, String fmt, Object... args) {
         kLevel(Level.DEBUG, eventType, context, mdc, fmt, null, args);
     }
 
@@ -32,11 +38,11 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
         kInfo(eventType, null, fmt, args);
     }
 
-    public void kInfo(String eventType, Map<String, String> mdc, String fmt, Object... args) {
+    public void kInfo(String eventType, Map<String, Object> mdc, String fmt, Object... args) {
         kInfo(eventType, null, mdc, fmt, args);
     }
 
-    public void kInfo(String eventType, String context, Map<String, String> mdc, String fmt, Object... args) {
+    public void kInfo(String eventType, String context, Map<String, Object> mdc, String fmt, Object... args) {
         kLevel(Level.INFO, eventType, context, mdc, fmt, null, args);
     }
 
@@ -44,11 +50,11 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
         kWarn(eventType, null, fmt, args);
     }
 
-    public void kWarn(String eventType, Map<String, String> mdc, String fmt, Object... args) {
+    public void kWarn(String eventType, Map<String, Object> mdc, String fmt, Object... args) {
         kWarn(eventType, null, mdc, fmt, args);
     }
 
-    public void kWarn(String eventType, String context, Map<String, String> mdc, String fmt, Object... args) {
+    public void kWarn(String eventType, String context, Map<String, Object> mdc, String fmt, Object... args) {
         kLevel(Level.WARN, eventType, context, mdc, fmt, null, args);
     }
 
@@ -56,11 +62,11 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
         kError(eventType, null, fmt, args);
     }
 
-    public void kError(String eventType, Map<String, String> mdc, String fmt, Object... args) {
+    public void kError(String eventType, Map<String, Object> mdc, String fmt, Object... args) {
         kError(eventType, null, mdc, fmt, args);
     }
 
-    public void kError(String eventType, String context, Map<String, String> mdc, String fmt, Object... args) {
+    public void kError(String eventType, String context, Map<String, Object> mdc, String fmt, Object... args) {
         kLevel(Level.ERROR, eventType, context, mdc, fmt, null, args);
     }
 
@@ -68,29 +74,84 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
         kError(eventType, null, fmt, ex);
     }
 
-    public void kError(String eventType, Map<String, String> mdc, String fmt, Throwable ex) {
+    public void kError(String eventType, Map<String, Object> mdc, String fmt, Throwable ex) {
         kError(eventType, null, mdc, fmt, ex);
     }
 
-    public void kError(String eventType, String context, Map<String, String> mdc, String fmt, Throwable ex) {
+    public void kError(String eventType, String context, Map<String, Object> mdc, String fmt, Throwable ex) {
         kLevel(Level.ERROR, eventType, context, mdc, fmt, ex);
     }
 
-    private void kLevel(Level level, String eventType, String context, Map<String, String> mdc, String fmt, Throwable ex, Object... args) {
+    public static class MetadataBinding implements AutoCloseable {
+        private final MDC.MDCCloseable underlying;
+        private MetadataBinding(MDC.MDCCloseable mdcCloseable) {
+            underlying = mdcCloseable;
+        }
+        @Override
+        public void close() {
+            underlying.close();
+        }
+    }
+
+    public MetadataBinding bindMetadata(String key, Object val) {
+        return new MetadataBinding(MDC.putCloseable(key, formatValue(val)));
+    }
+
+    public static class EventTimer implements AutoCloseable {
+        private final KinesisLogger logger;
+        private final String eventType;
+        private final String context;
+        private final long startMillis;
+        private EventTimer(KinesisLogger logger, String eventType, String context) {
+            this.logger = logger;
+            this.eventType = eventType;
+            this.context = context;
+            this.startMillis = System.currentTimeMillis();
+        }
+        private EventTimer(KinesisLogger logger, String eventType) {
+            this(logger, eventType, null);
+        }
+
+        @Override
+        public void close() {
+            long endMillis = System.currentTimeMillis();
+            logger.kInfo(eventType, context, Collections.singletonMap("took_millis", endMillis-startMillis), "");
+        }
+
+        public void stop() {
+            close();
+        }
+    }
+
+    public EventTimer timer(String eventType, String context) {
+        return new EventTimer(this, eventType, context);
+    }
+
+    public EventTimer timer(String eventType) {
+        return new EventTimer(this, eventType);
+    }
+
+    private static DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private String formatValue(Object val) {
+        if (val instanceof Date) return dateFormat.format((Date) val);
+        return val.toString();
+    }
+
+    private void kLevel(Level level, String eventType, String context, Map<String, Object> mdc, String fmt, Throwable ex, Object... args) {
+        ArrayList<MetadataBinding> boundMetadata = new ArrayList<>();
         if (mdc != null) {
-            for (Map.Entry<String, String> entry : mdc.entrySet()) {
-                MDC.put(entry.getKey(), entry.getValue());
+            for (Map.Entry<String, Object> entry : mdc.entrySet()) {
+                boundMetadata.add(bindMetadata(entry.getKey(), entry.getValue()));
             }
         }
 
         if (StringUtils.isNotBlank(eventType)) {
-            MDC.put("event_type", eventType);
+            boundMetadata.add(bindMetadata("event_type", eventType));
         }
 
         if (StringUtils.isNotBlank(context)) {
-            MDC.put("context", context);
+            boundMetadata.add(bindMetadata("context", context));
         }
-
         switch (level.toInt()) {
             case Level.DEBUG_INT:
                 logger.debug(fmt, args);
@@ -105,8 +166,8 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
                 if (ex == null) {
                     logger.error(fmt, args);
                 } else {
-                    MDC.put("exception", ex.getClass().getName());
-                    MDC.put("exceptionMessage", ex.getMessage());
+                    boundMetadata.add(bindMetadata("exception", ex.getClass().getName()));
+                    boundMetadata.add(bindMetadata("exceptionMessage", ex.getMessage()));
                     logger.error(fmt, ex);
                 }
                 break;
@@ -114,6 +175,8 @@ public class KinesisLogger extends LoggerWrapper implements Logger {
                 logger.trace(fmt, args);
         }
 
-        MDC.clear();
+        for (MetadataBinding closeable : boundMetadata) {
+            closeable.close();
+        }
     }
 }

--- a/src/test/java/com/hyp3r/services/kinesis/logback/ext/KinesisLoggerTest.java
+++ b/src/test/java/com/hyp3r/services/kinesis/logback/ext/KinesisLoggerTest.java
@@ -42,7 +42,7 @@ public class KinesisLoggerTest {
     private static final String MSG = "this is a debug message fmt {}";
     private static final String ARG = "FMT";
     private static final String FORMATTED_MESSAGE = MessageFormatter.arrayFormat(MSG, new Object[]{ARG}).getMessage();
-    private static final HashMap<String, String> MDC = new HashMap<>();
+    private static final HashMap<String, Object> MDC = new HashMap<>();
     private static final String EXCEPTION_MSG = "This is my exception message";
 
     static {
@@ -88,6 +88,35 @@ public class KinesisLoggerTest {
     @Test
     public void shouldCreateKinesisLoggerFactory() {
         new KinesisLoggerFactory();
+    }
+
+    @Test
+    public void logWithBoundMetadata() {
+        Throwable myThrowable = new IllegalArgumentException("SBH!");
+        KinesisLogger.MetadataBinding server = LOGGER.bindMetadata("server", "hyp3r.org");
+        try (KinesisLogger.MetadataBinding k1 = LOGGER.bindMetadata("k1", "v1");
+             KinesisLogger.MetadataBinding k2 = LOGGER.bindMetadata("k2", "v2")) {
+            LOGGER.kInfo("my_event", "This is the note for my event");
+        }
+        LOGGER.kError("my_error", "Something bad happened.", myThrowable);
+        verify(kinesisProducer, times(2)).addUserRecord(captoStreamName.capture(), captorUuid.capture(), captorByteBuffer.capture());
+        List<ByteBuffer> jsons = captorByteBuffer.getAllValues();
+        String json = new String(jsons.get(0).array());
+        System.out.println(json);
+        json = new String(jsons.get(1).array());
+        System.out.println(json);
+        server.close();
+    }
+
+    @Test
+    public void logWithEventTimer() throws Exception {
+        try (KinesisLogger.EventTimer timer =  LOGGER.timer("my_timed_event")) {
+            Thread.sleep(100);
+        }
+        verify(kinesisProducer).addUserRecord(captoStreamName.capture(), captorUuid.capture(), captorByteBuffer.capture());
+        List<ByteBuffer> jsons = captorByteBuffer.getAllValues();
+        String json = new String(jsons.get(0).array());
+        System.out.println(json);
     }
 
     @Test
@@ -339,7 +368,7 @@ public class KinesisLoggerTest {
         assertEquals(EVENT_TYPE, logEvent.getEventType());
         assertNull(logEvent.getContext());
         assertEquals(MSG, logEvent.getDescription());
-        assertNotNull(logEvent.getStacktrace());
+        assertNull(logEvent.getStacktrace());
         assertNotNull(logEvent.getTimestamp());
         assertTrue(logEvent.getMetadata().isEmpty());
 
@@ -352,7 +381,7 @@ public class KinesisLoggerTest {
         assertEquals(EVENT_TYPE, logEvent.getEventType());
         assertNull(logEvent.getContext());
         assertEquals(FORMATTED_MESSAGE, logEvent.getDescription());
-        assertNotNull(logEvent.getStacktrace());
+        assertNull(logEvent.getStacktrace());
         assertNotNull(logEvent.getTimestamp());
         assertTrue(logEvent.getMetadata().isEmpty());
 
@@ -365,7 +394,7 @@ public class KinesisLoggerTest {
         assertEquals(EVENT_TYPE, logEvent.getEventType());
         assertNull(logEvent.getContext());
         assertEquals(FORMATTED_MESSAGE, logEvent.getDescription());
-        assertNotNull(logEvent.getStacktrace());
+        assertNull(logEvent.getStacktrace());
         assertNotNull(logEvent.getTimestamp());
         assertTrue(logEvent.getMetadata().containsKey("key"));
         assertEquals("value", logEvent.getMetadata().get("key"));
@@ -379,7 +408,7 @@ public class KinesisLoggerTest {
         assertEquals(EVENT_TYPE, logEvent.getEventType());
         assertEquals(CONTEXT, logEvent.getContext());
         assertEquals(FORMATTED_MESSAGE, logEvent.getDescription());
-        assertNotNull(logEvent.getStacktrace());
+        assertNull(logEvent.getStacktrace());
         assertNotNull(logEvent.getTimestamp());
         assertTrue(logEvent.getMetadata().containsKey("key"));
         assertEquals("value", logEvent.getMetadata().get("key"));


### PR DESCRIPTION
This patch includes:

1. The stacktrace now uses the stacktrace of the exception, rather than the stack trace of the logger call.
1.  Convenience methods for long-lived or repeated metadata values and for timing events

This is not perfect and feedback is more than welcome.