### PR TITLE
Add global metadata bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Behold:
         KinesisLogger.MetadataBinding k0 = LOGGER.bindMetadata("k0", "v0");
 
 
-        try (KinesisLogger.MetadataBinding k1 = LOGGER.bindMetadata("k1", "v1");
-             KinesisLogger.MetadataBinding k2 = LOGGER.bindMetadata("k2", "v2")) {
+        try (KinesisLogger.MetadataBinding k1 = LOGGER.bindMetadata("k1", "v1")
+                                                               .and("k2", "v2")) {
 
             // Here, the metadata emitted will contain k0, k1, and k2
             LOGGER.kInfo("my_event", "This is the note for my event");
@@ -106,6 +106,22 @@ There is also a convenience method for emitting events about the duration of an 
         }
         // At this point, the timer is closed, and an event is emitted of type "api_fetch", with a key "took_millis
         //       added to the metadata along side any other active metadata bindings.
+
+```
+
+
+Lastly, you may want to set a permanent metadata binding that applies to every thread in your application (the bindings
+shown up to now are all thread-local).  You can do that too:
+
+```java
+
+        KinesisLogger.addGlobalMetadata("server_id", "192.168.1.1:8080");
+
+        //server_id will appear amongst the metadata for the remainder of the application's lifetime.
+        LOGGER.kInfo("my_event", "This is the note for my event");
+
+        //And you can clear all global metadata if you really want to:
+        KinesisLogger.clearGlobalMetadata();
 
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'signing'
 
 group = 'com.hyp3r'
 archivesBaseName = 'kinesis-logback-appender'
-version = '0.0.5'
+version = '0.0.6'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
I think this is the last change I'll want to make for the foreseeable future.
It does:
1>  Add the ability to create long-lived global metadata bindings that are not local to a thread.  This is useful for things like setting the server's identity to be included in all events.
2> Add the `and` method for more concisely setting up groups of closeable metadata bindings.  This makes setting many metadata items at one time much easier on the fingers (and the eyes).

I think I still don't have access to publish new versions of this library to the sonatype repo, but let me know if I'm wrong about that.